### PR TITLE
improved performance of Branch#makeMove

### DIFF
--- a/js/src/test/scala/com/mogproject/mogami/bench/BenchmarkJS.scala
+++ b/js/src/test/scala/com/mogproject/mogami/bench/BenchmarkJS.scala
@@ -5,6 +5,7 @@ import com.mogproject.mogami.core.state.StateConstant._
 import com.mogproject.mogami.core.PieceConstant._
 import com.mogproject.mogami.core.SquareConstant._
 import com.mogproject.mogami.core.move.MoveBuilderSfen
+import com.mogproject.mogami.core.state.StateCache
 
 
 /**
@@ -12,15 +13,20 @@ import com.mogproject.mogami.core.move.MoveBuilderSfen
   */
 object BenchmarkJS extends scalajs.js.JSApp with Benchmark with TestData {
   def main(): Unit = {
-//    benchAttack(BP, None, BitBoard.empty, BitBoard.empty)
-//
-//    benchAttack(BP, Some(P55), BitBoard.empty, BitBoard.empty)
-//
-//    benchAttack(BPR, Some(P11), BitBoard.empty, BitBoard.empty)
-//    benchAttack(BPR, Some(P11), BitBoard.full, BitBoard.full)
-//
-//    benchAttack(BPB, Some(P55), BitBoard.empty, BitBoard.empty)
-//    benchAttack(BPB, Some(P55), BitBoard.full, BitBoard.full)
+    benchGameLoad()
+  }
+
+  def misc(): Unit = {
+
+    //    benchAttack(BP, None, BitBoard.empty, BitBoard.empty)
+    //
+    //    benchAttack(BP, Some(P55), BitBoard.empty, BitBoard.empty)
+    //
+    //    benchAttack(BPR, Some(P11), BitBoard.empty, BitBoard.empty)
+    //    benchAttack(BPR, Some(P11), BitBoard.full, BitBoard.full)
+    //
+    //    benchAttack(BPB, Some(P55), BitBoard.empty, BitBoard.empty)
+    //    benchAttack(BPB, Some(P55), BitBoard.full, BitBoard.full)
 
     if (false) {
       benchGameLoading(recordSfen01)
@@ -35,11 +41,40 @@ object BenchmarkJS extends scalajs.js.JSApp with Benchmark with TestData {
       benchToSfenString(s)
     }
 
-//    benchCalcAttackBB(HIRATE)
-//    benchCalcAttackBBDiff(HIRATE, MoveBuilderSfen(Left(P77), P76, false))
+    //    benchCalcAttackBB(HIRATE)
+    //    benchCalcAttackBBDiff(HIRATE, MoveBuilderSfen(Left(P77), P76, false))
+  }
+
+  def benchGameLoad(): Unit = {
+    val repeat = 100
+
+    println(s"benchGameLoad: different cache")
+
+    withBenchmark {
+      var i = 0
+      while (i < repeat) {
+        StateCache.withCache { implicit cache =>
+          val g = Game.parseUsenString(recordUsen01)
+        }
+        i += 1
+      }
+    }.print()
 
 
+    println(s"benchGameLoad: same cache")
 
+    withBenchmark {
+      var i = 0
+      StateCache.withCache { implicit cache =>
+        while (i < repeat) {
+          val g = Game.parseUsenString(recordUsen01)
+          i += 1
+        }
+      }
+    }.print()
+  }
+
+  def benchMateSolver(): Unit = {
     val s1 = State.parseSfenString("4k4/9/9/9/3+PP4/9/9/9/9 b 4G2r2b4s4n4l16p") // mate in 9
     val s2 = State.parseSfenString("8k/7p1/1r7/5bS2/7N1/9/9/9/9 b RSNLb4g2s2n3l17p") // mate in 7
     val s3 = State.parseSfenString("1+P2Ss2l/1+S5b1/k1p4p1/1p+r1G2n1/p7p/P1N2S3/KPP1PP+pBP/7+r1/LNg6 b GNL2Pgl3p")
@@ -51,10 +86,10 @@ object BenchmarkJS extends scalajs.js.JSApp with Benchmark with TestData {
     val s9 = State.parseSfenString("5n1k1/5ps2/7p1/8N/7P1/9/9/9/9 b RBrb4g3s2n4l15p") // mate in 11
     benchMateSolver(s1)
     benchMateSolver(s2)
-//    benchMateSolver(s3)
+    //    benchMateSolver(s3)
     benchMateSolver(s4)
-//    benchMateSolver(s5)
-//    benchMateSolver(s6)
+    //    benchMateSolver(s5)
+    //    benchMateSolver(s6)
     benchMateSolver(s7)
     benchMateSolver(s8)
     benchMateSolver(s9)

--- a/shared/src/main/scala/com/mogproject/mogami/core/state/State.scala
+++ b/shared/src/main/scala/com/mogproject/mogami/core/state/State.scala
@@ -297,7 +297,7 @@ case class State(turn: Player = BLACK,
     val newOccs = getUpdatedOccupancy(move)
 
     val hint = StateHint(
-      hash ^ StateHash.getDifference(hand, move),
+      StateHash.getNextStateHash(this, move),
       newOccs._1,
       newOccs._2,
       newOccs._3,

--- a/shared/src/test/scala/com/mogproject/mogami/bench/Benchmark.scala
+++ b/shared/src/test/scala/com/mogproject/mogami/bench/Benchmark.scala
@@ -1,7 +1,7 @@
 package com.mogproject.mogami.bench
 
 import com.mogproject.mogami._
-import com.mogproject.mogami.core.state.State
+import com.mogproject.mogami.core.state.{State, StateCache}
 import com.mogproject.mogami.mate.MateSolver
 
 /**
@@ -21,12 +21,12 @@ case class BenchResult(result: Seq[Double]) {
 
 trait Benchmark {
 
-  import com.mogproject.mogami.core.state.StateCache.Implicits._
+//  import com.mogproject.mogami.core.state.StateCache.Implicits._
 
   val benchmarkCount = 3
   val attackRepeat = 10000
 
-  private[this] def withBenchmark(thunk: => Unit): BenchResult = {
+  protected def withBenchmark(thunk: => Unit): BenchResult = {
     val ret = (1 to benchmarkCount).map { n =>
       val start = System.currentTimeMillis()
       thunk
@@ -39,7 +39,9 @@ trait Benchmark {
     println(s"benchGameLoading: sfen=${sfen}")
 
     withBenchmark {
-      val g = Game.parseSfenString(sfen)
+      StateCache.withCache { implicit cache =>
+        val g = Game.parseSfenString(sfen)
+      }
     }.print()
   }
 

--- a/shared/src/test/scala/com/mogproject/mogami/bench/TestData.scala
+++ b/shared/src/test/scala/com/mogproject/mogami/bench/TestData.scala
@@ -23,4 +23,7 @@ trait TestData {
     " 6b4d+ 2d3c G*4c 4b4c 5d4c+ 3b2b 4d3c 2b1c N*2e 1c1b",
     " G*2b"
   ).mkString
+
+  // https://shogidb2.com/games/2ee6a9a3754841c721e904e5a5295583297d3dbf
+  val recordUsen01: String = "~0.7ku36e7bq0rs9us2jm8uc31u66q1sc83q31s9lo0io8cm0n88821im51q2o63wr1nq7ga2s68la1a49cm1e26ti0wu5oi0e48hq00i6y219087k09k9h4bf872m3t697m4289q82xabg851o7ls42a6ba3xq8h620s66q3t87222jo4ji2aibei1a04nj15i8kwbgq9l832a7d8bg8bes1ry7g8bh89lqbgq8c84be66s5gebok1e24nj1a0bl0bn2bfi3fibf01ai6t0bg092ibo2bt23ki4p0bfa4ji2aibfi3ei56c6lfbg852s7bs3tsboq2o6bok29i4ji3om3ej05i4nj15ibok2ai45x250bei3ei4nj15ibf02aibb23e0bei15ibsibii3ej15ic06b920dzbi4bjibe03ej15ibjm0am5xm3om4om3t4bl4bi47240b4b9mbzm840bd29424un984bck.r"
 }


### PR DESCRIPTION
before:
```
benchGameLoad: different cache

- avg: 6.257s, min: 5.951s, max: 6.627s

benchGameLoad: same cache

- avg: 1.652s, min: 1.637s, max: 1.662s
```

after:
```
benchGameLoad: different cache

- avg: 6.207s, min: 5.881s, max: 6.594s

benchGameLoad: same cache

- avg: 0.803s, min: 0.791s, max: 0.826s
```